### PR TITLE
DO NOT MERGE - Nuget Publishing POC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
       # generate the proper version
       - name: Run GitVersion
-        run: dotnet gitversion /updateassemblyinfo AssemblyGitInfo.cs /ensureassemblyinfo /output buildserver
+        run: dotnet gitversion /updateassemblyinfo AssemblyGitInfo.cs /ensureassemblyinfo
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
       # generate the proper version
       - name: Run GitVersion
-        run: dotnet gitversion /updateassemblyinfo AssemblyGitVersionInfo.cs /ensureassemblyinfo /output buildserver
+        run: dotnet gitversion /updateassemblyinfo Properties/AssemblyGitVersionInfo.cs /ensureassemblyinfo /output buildserver
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,81 @@
+name: publish
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+  release:
+    types:
+      - created
+
+jobs:
+  publish:
+    runs-on: windows-2019
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # this is required for GitVersion to work
+          fetch-depth: 0
+
+      - name: Setup Dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.0.2
+        with:
+          nuget-api-key: ${{ secrets.NUGET_APIKEY }}
+          nuget-version: 5.5.1
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+
+      - name: Setup GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9
+        with:
+          versionSpec: '5.1.x'
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+
+      # generate the proper version
+      - name: Run GitVersion
+        run: dotnet gitversion /updateassemblyinfo AssemblyGitInfo.cs /ensureassemblyinfo /output buildserver
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+
+      # restore all dependencies
+      - name: Nuget Restore
+        run: nuget restore Rampastring.Tools.csproj -PackagesDirectory packages
+
+      # build the project
+      - name: Build Project
+        run: dotnet msbuild Rampastring.Tools.csproj -property:Configuration=Release
+
+      # create a nuget package
+      - name: Nuget Package
+        run: nuget pack Rampastring.Tools.nuspec -BasePath bin\Release -OutputDirectory output_package -PackagesDirectory packages -Version ${{ env.GITVERSION_NUGETVERSION }}
+
+      # publish generated nuget packages to Nuget.org
+      - name: Nuget Publish
+        run: nuget push output_package\*.nupkg -Source https://api.nuget.org/v3/index.json
+        continue-on-error: true
+
+      # upload our nuget package to github artifacts
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: nupkg
+          path: output_package/
+
+      # upload our dll to github artifacts
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: build_artifacts
+          path: bin/Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
       # generate the proper version
       - name: Run GitVersion
-        run: dotnet gitversion /updateassemblyinfo AssemblyGitInfo.cs /ensureassemblyinfo
+        run: dotnet gitversion /updateassemblyinfo AssemblyGitVersionInfo.cs /ensureassemblyinfo
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
       # generate the proper version
       - name: Run GitVersion
-        run: dotnet gitversion /updateassemblyinfo AssemblyGitVersionInfo.cs /ensureassemblyinfo
+        run: dotnet gitversion /updateassemblyinfo AssemblyGitVersionInfo.cs /ensureassemblyinfo /output buildserver
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Icon?
 
 # Dolphin
 .directory
+/gitversion.json
+/packages
+/Properties/AssemblyGitVersionInfo.cs

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,13 @@
+# ContinuousDeployment forces the build number to be incremented by 1 for every commit that comes after the
+# most recent tag version.
+mode: ContinuousDeployment
+
+# When a version is created by a single commit, it will contain this suffix and an auto incremented build number.
+# Example: 1.1.7897-alpha0001
+# When a version is created by creating a tag/release, it will NOT contain this suffix.
+# Example: 1.1.7897
+continuous-delivery-fallback-tag: alpha
+branches: {}
+ignore:
+  sha: []
+merge-message-formats: {}

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -28,7 +28,6 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.*")]
+// Do not change.
+// This will be automatically updated by the Github Actions/GitVersion CLI workflow in a file AssemblyGitVersionInfo.cs.
+// [assembly: AssemblyVersion("x.x.x.x")]

--- a/Rampastring.Tools.csproj
+++ b/Rampastring.Tools.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\Debug\lib\net40</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\Release\lib\net40</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -59,16 +59,17 @@
     <Compile Include="IniSection.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyGitVersionInfo.cs" Condition="Exists('Properties\AssemblyGitVersionInfo.cs')" />
     <Compile Include="Utilities.cs" />
     <Compile Include="WindowFlasher.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Rampastring.Tools.nuspec
+++ b/Rampastring.Tools.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+  <metadata>
+    <id>devo1929.Rampastring.Tools</id>
+    <version>0.0.0</version>
+    <authors>Rampastring</authors>
+    <owners>Rampastring</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/Rampastring/Rampastring.Tools</projectUrl>
+    <description>Rampastring's Generally Useful Library</description>
+    <copyright>Copyright 2021</copyright>
+    <dependencies>
+      <group targetFramework=".NETFramework4.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+</packages>


### PR DESCRIPTION
This PR contains the necessary changes to get proper Nuget Publishing up and running for this repo. The same logic can then be applied to XNAUI where Tools could then be a dependency in it via Nuget, rather than committed DLLs.
I've been running this against my own fork and can confirm that it all works. It currently publishes a library to my own Nuget account named `devo1929.Rampastring.Tools`.

- This uses GitVersion to auto increment build versions on every commit. 
- GitVersion responsible for knowing when/how to increment the version of the library and whether or not it's an "alpha" version. This is done by it determining whether or not the _current_ commit is the same sha as an existing tag.
- GitVersion automatically updates the AssemblyVersion of the built DLL.
- An "alpha" instance of the library is published to Nuget anytime the master branch is updated. These will be visible in VS/Rider IDEs as a "prerelease" version.
- A non "alpha" instance of the library is published to Nuget anytime a release is created in Github. These will be visible in VS/Rider IDEs as a "release" version.