### PR TITLE
Target net 8 and netstandard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ permissions:
 jobs:
   publish:
     if: github.repository == 'Rampastring/Rampastring.Tools'
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - name: Checkout
       uses: actions/checkout@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@main
       with:
-        dotnet-version: '7.x.x'
+        dotnet-version: '8.x.x'
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@main
       with:

--- a/Rampastring.Tools.csproj
+++ b/Rampastring.Tools.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;net48</TargetFrameworks>
     <Title>Rampastring.Tools</Title>
     <Description>Rampastring's Generally Useful Library</Description>
     <Company>Rampastring</Company>

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -27,11 +27,11 @@ public static class Utilities
 
         using Stream stream = fileInfo.OpenRead();
 #pragma warning disable CA5350 // Do Not Use Weak Cryptographic Algorithms
-#if NETFRAMEWORK
+#if NET5_0_OR_GREATER
+        byte[] hash = SHA1.HashData(stream);
+#else
         using SHA1 sha1 = SHA1.Create();
         byte[] hash = sha1.ComputeHash(stream);
-#else
-        byte[] hash = SHA1.HashData(stream);
 #endif
 #pragma warning restore CA5350 // Do Not Use Weak Cryptographic Algorithms
 
@@ -47,11 +47,11 @@ public static class Utilities
     {
         byte[] buffer = Encoding.ASCII.GetBytes(str);
 #pragma warning disable CA5350 // Do Not Use Weak Cryptographic Algorithms
-#if NETFRAMEWORK
+#if NET7_0_OR_GREATER
+        byte[] hash = SHA1.HashData(buffer);
+#else
         using SHA1 sha1 = SHA1.Create();
         byte[] hash = sha1.ComputeHash(buffer);
-#else
-        byte[] hash = SHA1.HashData(buffer);
 #endif
 #pragma warning restore CA5350 // Do Not Use Weak Cryptographic Algorithms
         return BytesToString(hash);

--- a/WindowFlasher.cs
+++ b/WindowFlasher.cs
@@ -12,7 +12,7 @@ public static class WindowFlasher
     /// </summary>
     /// <param name="windowHandle">The handle of the window to flash.</param>
     /// <returns>The return value fo FlashWindowEx.</returns>
-#if !NETFRAMEWORK
+#if NET5_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows5.1.2600")]
 #endif
     public static bool FlashWindowEx(IntPtr windowHandle)


### PR DESCRIPTION
This PR updates framework target to .NET8, .NET Standard 2.0, and .NET 4.8, dropping .NET 7 support.
It also fixes incorrect #if which causes compilation error for .NET Standard 2.0.

Introducing .NET Standard 2.0 target is for two SecondStageUpdaters, where executables in .NET 4.8 and .NET 8 reside in the same folder.