### PR TITLE
Disable `IsReadOnly` property before file would be safely deleted

### DIFF
--- a/SafePath.cs
+++ b/SafePath.cs
@@ -63,8 +63,11 @@ public static class SafePath
     {
         var fileInfo = new FileInfo(CombineFilePath(paths));
 
-        if (fileInfo.Exists)
-            fileInfo.Delete();
+        if (!fileInfo.Exists)
+            return;
+
+        fileInfo.IsReadOnly = false;
+        fileInfo.Delete();
     }
 
     /// <summary>


### PR DESCRIPTION
As mentioned in https://github.com/CnCNet/xna-cncnet-client/pull/613, because CnCNet client has implemented links, it would be better to add in `SafePath`'s `DeleteFileIfExists` method disabling `Read Only` property before file would be deleted, which will cost much less constant copy and paste code with checks for this property is disabled.