### PR TITLE
Ignore .lscache files generated by C# Dev Kit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,6 +384,9 @@ FodyWeavers.xsd
 !.vscode/extensions.json
 *.code-workspace
 
+# Official VS Code C# Dev Kit Extension exclusion
+*.lscache
+
 # Local History for Visual Studio Code
 .history/
 


### PR DESCRIPTION
Pretty annoying
<img width="2054" height="878" alt="图片" src="https://github.com/user-attachments/assets/8a01ddb6-f76a-49de-b663-15bd8a2cd54a" />
